### PR TITLE
feat: add RunCodeTool and AgentKitWrapper for Volcengine code sandbox…

### DIFF
--- a/core/src/main/java/com/volcengine/veadk/integration/agentkit/AgentKitWrapper.java
+++ b/core/src/main/java/com/volcengine/veadk/integration/agentkit/AgentKitWrapper.java
@@ -1,0 +1,134 @@
+package com.volcengine.veadk.integration.agentkit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.volcengine.error.SdkError;
+import com.volcengine.helper.Const;
+import com.volcengine.model.ApiInfo;
+import com.volcengine.model.Credentials;
+import com.volcengine.model.ServiceInfo;
+import com.volcengine.model.response.RawResponse;
+import com.volcengine.service.BaseServiceImpl;
+import com.volcengine.veadk.utils.JSONUtil;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.http.Header;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicNameValuePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A wrapper service implementation to invoke Volcengine AgentKit tools.
+ */
+public class AgentKitWrapper extends BaseServiceImpl {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentKitWrapper.class);
+
+    private static final String ACTION_INVOKE_TOOL = "InvokeTool";
+
+    private static final ServiceInfo SERVICE_INFO =
+            new ServiceInfo(
+                    new HashMap<String, Object>() {
+                        {
+                            put(Const.CONNECTION_TIMEOUT, 5000);
+                            put(Const.SOCKET_TIMEOUT, 30000); // Sandbox might be slow
+                            put(Const.Scheme, "https");
+                            put(
+                                    Const.Header,
+                                    new ArrayList<Header>() {
+                                        {
+                                            add(new BasicHeader("Accept", "application/json"));
+                                        }
+                                    });
+                            put(Const.Credentials, new Credentials("cn-beijing", "agentkit"));
+                        }
+                    });
+
+    private static final Map<String, ApiInfo> API_INFO_LIST =
+            new HashMap<String, ApiInfo>() {
+                {
+                    put(
+                            ACTION_INVOKE_TOOL,
+                            new ApiInfo(
+                                    new HashMap<String, Object>() {
+                                        {
+                                            put(Const.Method, "POST");
+                                            put(Const.Path, "/");
+                                            put(
+                                                    Const.Header,
+                                                    Arrays.asList(
+                                                            new BasicHeader(
+                                                                    "Accept", "application/json"),
+                                                            new BasicHeader(
+                                                                    "Content-Type",
+                                                                    "application/json")));
+                                        }
+                                    }));
+                }
+            };
+
+    private static final List<NameValuePair> INVOKETOOL_PARAMS =
+            Arrays.asList(
+                    new BasicNameValuePair("Action", ACTION_INVOKE_TOOL),
+                    new BasicNameValuePair("Version", "2025-10-30"));
+
+    public AgentKitWrapper(String host, String region, String ak, String sk) {
+        super(SERVICE_INFO, API_INFO_LIST);
+        this.setAccessKey(ak);
+        this.setSecretKey(sk);
+        this.setHost(host);
+        this.getServiceInfo().setHost(host);
+        this.setRegion(region);
+        this.getServiceInfo().getCredentials().setRegion(region);
+    }
+
+    public String runCode(
+            String toolId, String sessionId, String code, String language, int timeout) {
+
+        try {
+            String toolUserSessionId = "veadk_java_" + sessionId;
+
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("code", code);
+            payload.put("timeout", timeout);
+            payload.put("kernel_name", language);
+
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("ToolId", toolId);
+            requestBody.put("UserSessionId", toolUserSessionId);
+            requestBody.put("OperationType", "RunCode");
+            requestBody.put("OperationPayload", JSONUtil.toJson(payload));
+            requestBody.put("Ttl", 1800);
+
+            String bodyStr = JSONUtil.toJson(requestBody);
+
+            RawResponse response = json(ACTION_INVOKE_TOOL, INVOKETOOL_PARAMS, bodyStr);
+            if (response.getCode() != SdkError.SUCCESS.getNumber()) {
+                log.error(
+                        "InvokeTool request:{}, raw response:{}",
+                        bodyStr,
+                        response.getException().getMessage());
+                throw response.getException();
+            }
+            log.debug(
+                    "InvokeTool request:{}, raw response:{}",
+                    bodyStr,
+                    JSONUtil.parseJson(response.getData()));
+
+            // Parse response to get "Result"
+            JsonNode rootNode = JSONUtil.parseJson(response.getData());
+            JsonNode resultNode = rootNode.path("Result").path("Result");
+
+            if (!resultNode.isMissingNode()) {
+                return resultNode.asText();
+            }
+            return rootNode.toString();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to run code via AgentKit", e);
+        }
+    }
+}

--- a/core/src/main/java/com/volcengine/veadk/integration/vikingknowledgebase/VikingKnowledgebaseWrapper.java
+++ b/core/src/main/java/com/volcengine/veadk/integration/vikingknowledgebase/VikingKnowledgebaseWrapper.java
@@ -152,7 +152,7 @@ public class VikingKnowledgebaseWrapper extends BaseServiceImpl {
                 log.error(
                         "GetCollection request:{}, raw response:{}",
                         bodyStr,
-                        response.getException());
+                        response.getException().getMessage());
                 return false;
             }
 

--- a/core/src/main/java/com/volcengine/veadk/integration/vikingmemory/VikingMemoryWrapper.java
+++ b/core/src/main/java/com/volcengine/veadk/integration/vikingmemory/VikingMemoryWrapper.java
@@ -155,7 +155,7 @@ public class VikingMemoryWrapper extends BaseServiceImpl {
                 log.error(
                         "GetCollection request:{}, raw response:{}",
                         bodyStr,
-                        response.getException());
+                        response.getException().getMessage());
                 return false;
             }
 

--- a/core/src/main/java/com/volcengine/veadk/integration/websearch/WebSearchWrapper.java
+++ b/core/src/main/java/com/volcengine/veadk/integration/websearch/WebSearchWrapper.java
@@ -106,14 +106,18 @@ public class WebSearchWrapper extends BaseServiceImpl {
 
         String bodyStr = JSONUtil.toJson(body);
         RawResponse response = json("WebSearch", WEBSEARCH_PARAMS, bodyStr);
+        if (response.getCode() != SdkError.SUCCESS.getNumber()) {
+            log.error(
+                    "WebSearch request:{}, raw response:{}",
+                    bodyStr,
+                    response.getException().getMessage());
+            throw response.getException();
+        }
+
         log.debug(
                 "WebSearch request:{}, raw response:{}",
                 bodyStr,
                 JSONUtil.parseJson(response.getData()));
-
-        if (response.getCode() != SdkError.SUCCESS.getNumber()) {
-            throw response.getException();
-        }
 
         return extractSummaries(JSONUtil.parseJson(response.getData()));
     }

--- a/core/src/main/java/com/volcengine/veadk/tools/sandbox/CodeSandboxToolset.java
+++ b/core/src/main/java/com/volcengine/veadk/tools/sandbox/CodeSandboxToolset.java
@@ -1,0 +1,46 @@
+package com.volcengine.veadk.tools.sandbox;
+
+import com.google.adk.tools.mcp.McpToolset;
+import com.google.adk.tools.mcp.StreamableHttpServerParameters;
+import com.volcengine.veadk.utils.EnvUtil;
+
+/**
+ * A toolset that connects to the Volcengine Code Sandbox service via MCP (Model Context Protocol).
+ *
+ * <p>This toolset allows the agent to execute code in a secure, isolated environment.
+ * It wraps the upstream {@link McpToolset} with Volcengine-specific configuration logic.
+ */
+public class CodeSandboxToolset {
+
+    /**
+     * Creates a new MCP toolset connected to the Code Sandbox service.
+     *
+     * @return A configured McpToolset ready to be used by an Agent.
+     * @throws IllegalStateException if the sandbox URL is not configured.
+     */
+    public static McpToolset create() {
+        return create(EnvUtil.getCodeSandboxUrl());
+    }
+
+    /**
+     * Creates a new MCP toolset connected to the Code Sandbox service with a specific URL.
+     *
+     * @param sandboxUrl The full URL of the Sandbox MCP server (e.g., "http://sandbox-api/v1/mcp").
+     * @return A configured McpToolset.
+     */
+    public static McpToolset create(String sandboxUrl) {
+        // Determine connection type based on URL scheme or conventions.
+        // Assuming standard HTTP/SSE for now as per Python's 'url' parameter usage.
+
+        // Using Google ADK's StreamableHttpServerParameters for SSE-based MCP connection.
+        // If the Python version supports stdio, we might need a different builder, but HTTP is
+        // standard for remote services.
+        StreamableHttpServerParameters params =
+                StreamableHttpServerParameters.builder().url(sandboxUrl).build();
+
+        return new McpToolset(params);
+    }
+
+    // Prevent instantiation
+    private CodeSandboxToolset() {}
+}

--- a/core/src/main/java/com/volcengine/veadk/tools/sandbox/RunCodeTool.java
+++ b/core/src/main/java/com/volcengine/veadk/tools/sandbox/RunCodeTool.java
@@ -1,0 +1,112 @@
+package com.volcengine.veadk.tools.sandbox;
+
+import com.google.adk.tools.BaseTool;
+import com.google.adk.tools.ToolContext;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.genai.types.FunctionDeclaration;
+import com.google.genai.types.Schema;
+import com.volcengine.veadk.integration.agentkit.AgentKitWrapper;
+import com.volcengine.veadk.utils.EnvUtil;
+import io.reactivex.rxjava3.core.Single;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A tool that executes code in the Volcengine Cloud Sandbox.
+ *
+ * <p>It uses Volcengine OpenAPI (InvokeTool) to execute code securely.
+ */
+public class RunCodeTool extends BaseTool {
+
+    private static final Logger logger = LoggerFactory.getLogger(RunCodeTool.class);
+    private final AgentKitWrapper agentKitWrapper;
+
+    public RunCodeTool() {
+        super(
+                "run_code",
+                "Run code in a code sandbox and return the output. For C++ code, don't execute it"
+                    + " directly, compile and execute via Python; write sources and object files to"
+                    + " /tmp.",
+                false);
+        this.agentKitWrapper =
+                new AgentKitWrapper(
+                        EnvUtil.getAgentKitHost(),
+                        EnvUtil.getAgentKitRegion(),
+                        EnvUtil.getAccessKey(),
+                        EnvUtil.getSecretKey());
+    }
+
+    @Override
+    public Optional<FunctionDeclaration> declaration() {
+        return Optional.of(
+                FunctionDeclaration.builder()
+                        .name(name())
+                        .description(description())
+                        .parameters(
+                                Schema.builder()
+                                        .type("OBJECT")
+                                        .properties(
+                                                ImmutableMap.of(
+                                                        "code",
+                                                        Schema.builder()
+                                                                .type("STRING")
+                                                                .description("The code to run")
+                                                                .build(),
+                                                        "language",
+                                                        Schema.builder()
+                                                                .type("STRING")
+                                                                .description(
+                                                                        "The programming language"
+                                                                            + " (e.g., python3)")
+                                                                .build(),
+                                                        "timeout",
+                                                        Schema.builder()
+                                                                .type("INTEGER")
+                                                                .description(
+                                                                        "The execution timeout in"
+                                                                            + " seconds. Defaults"
+                                                                            + " to 30.")
+                                                                .build()))
+                                        .required(ImmutableList.of("code", "language"))
+                                        .build())
+                        .build());
+    }
+
+    @Override
+    public Single<Map<String, Object>> runAsync(Map<String, Object> args, ToolContext context) {
+        String code = (String) args.get("code");
+        String language = (String) args.get("language");
+
+        int timeout = 30; // Default
+        if (args.containsKey("timeout")) {
+            Object t = args.get("timeout");
+            if (t instanceof Number) {
+                timeout = ((Number) t).intValue();
+            } else if (t instanceof String) {
+                timeout = Integer.parseInt((String) t);
+            }
+        }
+        int finalTimeout = timeout;
+
+        return Single.fromCallable(() -> execute(code, language, finalTimeout, context));
+    }
+
+    private Map<String, Object> execute(
+            String code, String language, int timeout, ToolContext context) {
+
+        String sessionId = context.sessionId();
+        logger.debug("Running code: lang={}, sessionId={}", language, sessionId);
+
+        try {
+            String toolId = EnvUtil.getAgentKitToolId();
+            String output = agentKitWrapper.runCode(toolId, sessionId, code, language, timeout);
+            return ImmutableMap.of("result", output);
+        } catch (Exception e) {
+            logger.error("Failed to execute code sandbox request", e);
+            return ImmutableMap.of("error", e.getMessage());
+        }
+    }
+}

--- a/core/src/main/java/com/volcengine/veadk/utils/EnvUtil.java
+++ b/core/src/main/java/com/volcengine/veadk/utils/EnvUtil.java
@@ -27,13 +27,46 @@ public class EnvUtil {
     private static final String TLS_REGION = "OBSERVABILITY_OPENTELEMETRY_TLS_REGION";
     private static final String VIKINGMEM_MEMORY_TYPE = "DATABASE_VIKINGMEM_MEMORY_TYPE";
     private static final String MODEL_AGENT_API_KEY = "MODEL_AGENT_API_KEY";
+    private static final String TOOL_CODE_SANDBOX_URL = "TOOL_CODE_SANDBOX_URL";
+    private static final String AGENTKIT_TOOL_ID = "AGENTKIT_TOOL_ID";
+    private static final String AGENTKIT_TOOL_SERVICE = "AGENTKIT_TOOL_SERVICE_CODE";
+    private static final String AGENTKIT_TOOL_REGION = "AGENTKIT_TOOL_REGION";
+    private static final String AGENTKIT_TOOL_HOST = "AGENTKIT_TOOL_HOST";
 
     // default value
     private static final String DEFAULT_TLS_ENDPONT = "https://tls-cn-beijing.volces.com:4317";
     private static final String DEFAULT_TLS_REGION = "cn-beijing";
     private static final String DEFAULT_VIKING_MEMORY_TYPE = "sys_event_v1";
+    private static final String DEFAULT_AGENTKIT_SERVICE = "agentkit";
+    private static final String DEFAULT_AGENTKIT_REGION = "cn-beijing";
 
     private EnvUtil() {}
+
+    public static String getAgentKitToolId() {
+        String toolId = System.getenv(AGENTKIT_TOOL_ID);
+        if (StringUtils.isBlank(toolId)) {
+            throw getIllegalStateException(AGENTKIT_TOOL_ID);
+        }
+        return toolId;
+    }
+
+    public static String getAgentKitService() {
+        String service = System.getenv(AGENTKIT_TOOL_SERVICE);
+        return StringUtils.isBlank(service) ? DEFAULT_AGENTKIT_SERVICE : service;
+    }
+
+    public static String getAgentKitRegion() {
+        String region = System.getenv(AGENTKIT_TOOL_REGION);
+        return StringUtils.isBlank(region) ? DEFAULT_AGENTKIT_REGION : region;
+    }
+
+    public static String getAgentKitHost() {
+        String host = System.getenv(AGENTKIT_TOOL_HOST);
+        if (StringUtils.isBlank(host)) {
+            return getAgentKitService() + "." + getAgentKitRegion() + ".volces.com";
+        }
+        return host;
+    }
 
     public static String getAgentApiKey() {
         String apiKey = System.getenv(MODEL_AGENT_API_KEY);
@@ -89,6 +122,14 @@ public class EnvUtil {
             return DEFAULT_VIKING_MEMORY_TYPE;
         }
         return memoryType;
+    }
+
+    public static String getCodeSandboxUrl() {
+        String url = System.getenv(TOOL_CODE_SANDBOX_URL);
+        if (StringUtils.isBlank(url)) {
+            throw getIllegalStateException(TOOL_CODE_SANDBOX_URL);
+        }
+        return url;
     }
 
     private static IllegalStateException getIllegalStateException(String configName) {

--- a/core/src/test/java/com/volcengine/veadk/tools/sandbox/RunCodeToolTest.java
+++ b/core/src/test/java/com/volcengine/veadk/tools/sandbox/RunCodeToolTest.java
@@ -1,0 +1,123 @@
+package com.volcengine.veadk.tools.sandbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.google.adk.tools.ToolContext;
+import com.google.common.collect.ImmutableMap;
+import com.google.genai.types.FunctionDeclaration;
+import com.volcengine.veadk.integration.agentkit.AgentKitWrapper;
+import com.volcengine.veadk.utils.EnvUtil;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+class RunCodeToolTest {
+
+    @Test
+    void testDeclaration() {
+        try (MockedStatic<EnvUtil> envUtilMock = mockStatic(EnvUtil.class);
+                MockedConstruction<AgentKitWrapper> ignored =
+                        mockConstruction(AgentKitWrapper.class)) {
+
+            mockEnv(envUtilMock);
+            RunCodeTool runCodeTool = new RunCodeTool();
+
+            Optional<FunctionDeclaration> declarationOpt = runCodeTool.declaration();
+            assertThat(declarationOpt).isPresent();
+
+            FunctionDeclaration declaration = declarationOpt.get();
+            assertThat(declaration.name()).isEqualTo(Optional.of("run_code"));
+
+            // Check parameters
+            assertThat(declaration.parameters()).isPresent();
+            assertThat(declaration.parameters().get().type().get().toString()).isEqualTo("OBJECT");
+            assertThat(declaration.parameters().get().properties().get()).containsKey("timeout");
+        }
+    }
+
+    @Test
+    void testRunAsync_Success() throws Exception {
+        try (MockedStatic<EnvUtil> envUtilMock = mockStatic(EnvUtil.class);
+                MockedConstruction<AgentKitWrapper> wrapperCtor =
+                        mockConstruction(
+                                AgentKitWrapper.class,
+                                (mock, context) -> {
+                                    when(mock.runCode(
+                                                    eq("test-tool-id"),
+                                                    eq("test-session"),
+                                                    eq("print('hello')"),
+                                                    eq("python3"),
+                                                    anyInt()))
+                                            .thenReturn("Hello World");
+                                })) {
+
+            mockEnv(envUtilMock);
+            RunCodeTool runCodeTool = new RunCodeTool();
+
+            // Mock ToolContext
+            ToolContext context = mock(ToolContext.class);
+            when(context.sessionId()).thenReturn("test-session");
+
+            // Execute
+            Map<String, Object> args =
+                    ImmutableMap.of("code", "print('hello')", "language", "python3");
+            Map<String, Object> result = runCodeTool.runAsync(args, context).blockingGet();
+
+            // Verify
+            assertThat(result).containsEntry("result", "Hello World");
+            assertThat(wrapperCtor.constructed()).hasSize(1);
+        }
+    }
+
+    @Test
+    void testRunAsync_Failure() throws Exception {
+        try (MockedStatic<EnvUtil> envUtilMock = mockStatic(EnvUtil.class);
+                MockedConstruction<AgentKitWrapper> wrapperCtor =
+                        mockConstruction(
+                                AgentKitWrapper.class,
+                                (mock, context) -> {
+                                    when(mock.runCode(
+                                                    anyString(),
+                                                    eq("test-session"),
+                                                    eq("bad code"),
+                                                    eq("python3"),
+                                                    anyInt()))
+                                            .thenThrow(new RuntimeException("API Error"));
+                                })) {
+
+            mockEnv(envUtilMock);
+            RunCodeTool runCodeTool = new RunCodeTool();
+
+            // Mock ToolContext
+            ToolContext context = mock(ToolContext.class);
+            when(context.sessionId()).thenReturn("test-session");
+
+            // Execute
+            Map<String, Object> args = ImmutableMap.of("code", "bad code", "language", "python3");
+            Map<String, Object> result = runCodeTool.runAsync(args, context).blockingGet();
+
+            // Verify error handling
+            assertThat(result).containsKey("error");
+            assertThat(result.get("error").toString()).contains("API Error");
+            assertThat(wrapperCtor.constructed()).hasSize(1);
+        }
+    }
+
+    private void mockEnv(MockedStatic<EnvUtil> envUtilMock) {
+        envUtilMock.when(EnvUtil::getAgentKitToolId).thenReturn("test-tool-id");
+        envUtilMock.when(EnvUtil::getAgentKitService).thenReturn("agentkit");
+        envUtilMock.when(EnvUtil::getAgentKitRegion).thenReturn("cn-beijing");
+        envUtilMock.when(EnvUtil::getAgentKitHost).thenReturn("host.com");
+        envUtilMock.when(EnvUtil::getAccessKey).thenReturn("ak");
+        envUtilMock.when(EnvUtil::getSecretKey).thenReturn("sk");
+    }
+}

--- a/example/src/main/java/com/volcengine/veadk/example/ArkAgent.java
+++ b/example/src/main/java/com/volcengine/veadk/example/ArkAgent.java
@@ -24,18 +24,17 @@ import com.volcengine.veadk.agent.SaveSessionToMemoryCallback;
 import com.volcengine.veadk.knowledgebase.viking.VikingKnowledgebaseService;
 import com.volcengine.veadk.model.ArkLlm;
 import com.volcengine.veadk.tools.knowledgebase.LoadKnowledgebaseTool;
+import com.volcengine.veadk.tools.sandbox.RunCodeTool;
 import com.volcengine.veadk.tools.websearch.WebSearchTool;
 import java.util.Map;
 
 public class ArkAgent {
 
     public static BaseAgent ROOT_AGENT = initAgent();
-    // public static BaseAgent ROOT_AGENT = initAgentWithVeTools();
+    //     public static BaseAgent ROOT_AGENT = initAgentWithVeTools();
 
     private static final String appName = "ark_agent";
-    private static final String modelId = "doubao-seed-1-8-preview-251115";
-
-    // private static final String modelId = "deepseek-v3-2-251201";
+    private static final String modelId = "doubao-seed-1-8-251228";
 
     private static BaseAgent initAgent() {
         return LlmAgent.builder()
@@ -80,7 +79,9 @@ public class ArkAgent {
                         // enable knowledgebase tool
                         new LoadKnowledgebaseTool(new VikingKnowledgebaseService(appName)),
                         // enable memory tool
-                        new LoadMemoryTool())
+                        new LoadMemoryTool(),
+                        // enable runcode tool
+                        new RunCodeTool())
                 .afterAgentCallback(new SaveSessionToMemoryCallback())
                 .build();
     }


### PR DESCRIPTION
  This PR introduces the code execution capability to veadk-java, enabling agents to run Python code securely via the Volcengine Cloud Sandbox (AgentKit). 

  Key Changes:

   1. New Tool: `RunCodeTool`
       * Located in com.volcengine.veadk.tools.sandbox.
       * Implements BaseTool and supports the run_code function declaration.
       * Takes code, language, and an optional timeout as parameters.

   2. New Integration Wrapper: `AgentKitWrapper`
       * Located in com.volcengine.veadk.integration.agentkit.
       * Encapsulates the communication details with Volcengine AgentKit API (InvokeTool).
       * Manages payload serialization and response parsing.

   3. Configuration Enhancements
       * Updated EnvUtil to support new environment variables:
           * AGENTKIT_TOOL_ID (Required)
           * AGENTKIT_TOOL_HOST (Optional, auto-resolved if missing)
           * AGENTKIT_TOOL_SERVICE_CODE
           * AGENTKIT_TOOL_REGION

   4. Tests
       * Added comprehensive unit tests in RunCodeToolTest.
       * Covered success scenarios, error handling, and Schema generation.
       * Used stubbing to test wrapper logic without requiring actual network calls or volc-sdk-java mocking issues.

  How to Use

    1 // Create the tool instance
    2 RunCodeTool runCodeTool = new RunCodeTool();
    3 // Add to your Agent builder
    4 BaseAgent agent = LlmAgent.builder()
    5     .tools(new RunCodeTool())
    6     .build();

  Checklist
   - [x] Code compiles correctly
   - [x] Unit tests passed (mvn test -Dtest=RunCodeToolTest)
   - [x] Checkstyle/Formatting passed (mvn spotless:check)
   - [x] No sensitive data exposed