### PR TITLE
chore: pin OpenTelemetry SDK/API to 1.62.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>com.volcengine.veadk</groupId>
         <artifactId>veadk-parent</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2</version>
     </parent>
 
     <artifactId>veadk-java</artifactId>

--- a/core/src/main/java/com/volcengine/veadk/Version.java
+++ b/core/src/main/java/com/volcengine/veadk/Version.java
@@ -16,7 +16,7 @@
 package com.volcengine.veadk;
 
 public final class Version {
-    public static final String JAVA_VEADK_VERSION = "0.0.1";
+    public static final String JAVA_VEADK_VERSION = "0.0.2";
 
     private Version() {}
 }

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <parent>
         <groupId>com.volcengine.veadk</groupId>
         <artifactId>veadk-parent</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2</version>
     </parent>
 
     <artifactId>example</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
 
     <groupId>com.volcengine.veadk</groupId>
     <artifactId>veadk-parent</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <packaging>pom</packaging>
 
     <name>Volcengine Agent Development Kit Maven Parent POM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@ limitations under the License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <google.adk.version>0.4.0</google.adk.version>
+        <opentelemetry.version>1.62.0</opentelemetry.version>
         <ark.sdk.version>0.2.48</ark.sdk.version>
         <volc.sdk.version>1.0.250</volc.sdk.version>
         <jackson.version>2.18.2</jackson.version>
@@ -84,6 +85,16 @@ limitations under the License.
 
     <dependencyManagement>
         <dependencies>
+            <!-- OpenTelemetry BOM: pin SDK/API to >= 1.62.0, overriding the
+                 version brought in transitively by google-adk. Declared first
+                 so it takes precedence over transitively-managed versions. -->
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- The ADK core dependency -->
             <dependency>
                 <groupId>com.google.adk</groupId>


### PR DESCRIPTION
## What

Pin OpenTelemetry Java (SDK/API) to **1.62.0** by importing `opentelemetry-bom:1.62.0` in the root `dependencyManagement`.

## Why

`veadk-java` does not declare OpenTelemetry directly — it inherits it transitively through `com.google.adk:google-adk:0.4.0`, whose parent BOM pins OpenTelemetry to **1.49.0**. We need OpenTelemetry Java (SDK/API) **>= 1.62.0**.

Importing the stable `opentelemetry-bom` directly in this project's `dependencyManagement` (declared first) overrides the transitively-managed versions.

## Verification

`mvn -pl core -am dependency:tree -Dincludes=io.opentelemetry` now resolves the stable artifacts to 1.62.0:

```
io.opentelemetry:opentelemetry-api:jar:1.62.0:compile
io.opentelemetry:opentelemetry-sdk:jar:1.62.0:compile
io.opentelemetry:opentelemetry-sdk-trace:jar:1.62.0:compile
io.opentelemetry:opentelemetry-sdk-logs:jar:1.62.0:compile
io.opentelemetry:opentelemetry-exporter-otlp:jar:1.62.0:compile
io.opentelemetry:opentelemetry-context:jar:1.62.0:compile
io.opentelemetry:opentelemetry-common:jar:1.62.0:compile
```

`mvn -pl core -am test-compile` passes (BUILD SUCCESS), confirming the bump is compile-compatible.

## Note

`opentelemetry-api-incubator` (an unstable `-alpha` artifact pulled in transitively by `google-adk`) is intentionally **left at its current version** and not managed here — the stable `opentelemetry-bom` does not cover `-alpha` artifacts, and forcing the incubator forward across many versions risks breaking `google-adk`'s usage of those unstable APIs. The requirement targets the stable SDK/API, which is satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)