### PR TITLE
docs: add security policy (SECURITY.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,5 +103,9 @@ Start command:
 - Unable to access memory/knowledgebase/search services: check AK/SK and network connectivity.
 - Port occupied: if port `8000` is occupied, adjust via `--server.port` or in the startup parameters of `AdkWeb.main`.
 
+## Security and privacy
+This project takes security seriously.
+For vulnerability reporting and supported versions, see [SECURITY.md](SECURITY.md)
+
 ## License
 This project uses the Apache License 2.0; see the `LICENSE` file for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+## Security and privacy
+
+If you discover potential security issues in the project, or believe you may have found a security issue, please notify the ByteDance security team through our [security center](https://security.bytedance.com/src/) or [vulnerability reporting email](mailto:src@bytedance.com). Please do not create public GitHub Issues.
+
+We will assess the vulnerability based on the Common Vulnerability Scoring System (CVSS 3.1). The security team will keep you updated on key progress and may request further information or guidance from you. You are welcome to contact us via the email or website mentioned above to ask questions or discuss disclosure matters.
+
+To protect the security of our customers, ByteDance requests that you do not publish or share information regarding the vulnerability in any public forum, nor publish or share data involving users, until the vulnerability has been remediated and our users have been notified. Please understand that the time required for remediation depends on the severity of the vulnerability and the scope of the impact.
+
+Individuals, companies, and security teams may wish to publish security advisories on their own websites or other forums. Please contact us via the email or website mentioned above prior to publication to discuss the information that can be disclosed and to coordinate the disclosure timeline.
+
+## Bug Bounty Reward
+
+[For the policy of bug bounty reward](https://bytedance.larkoffice.com/docx/ZstQd7bbooDctqxBCAmcFasOngd), if you have any questions about the rules, please contact [https://src.bytedance.com/home](https://src.bytedance.com/home) for consultation.


### PR DESCRIPTION
## What

- Add **`SECURITY.md`** at the repository root, documenting how to report security vulnerabilities to the ByteDance security team (security center / `src@bytedance.com`), the CVSS 3.1 assessment process, coordinated-disclosure expectations, and the bug bounty policy.
- Add a **"Security and privacy"** section to the README that links to `SECURITY.md`.

## Why

The repository previously had no security policy or vulnerability-reporting channel. This gives security researchers a clear, private path to report issues (instead of public GitHub Issues) and surfaces it from the README. GitHub also automatically picks up a root `SECURITY.md` and shows a "Report a vulnerability" / Security entry for the repo.

## Changes

- `SECURITY.md` (new)
- `README.md` — new "Security and privacy" section linking to `SECURITY.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)